### PR TITLE
feat: Add 'About Me' field to Join Club form

### DIFF
--- a/src/components/modals/JoinClubModal.tsx
+++ b/src/components/modals/JoinClubModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
+import { Textarea } from '@/components/ui/textarea';
 
 interface JoinClubModalProps {
   isOpen: boolean;
@@ -11,6 +12,7 @@ interface FormData {
   phone: string;
   email: string;
   submarineId: string;
+  aboutMe?: string; // Added optional aboutMe field
 }
 
 interface ApiResponse {
@@ -158,6 +160,17 @@ const JoinClubModal: React.FC<JoinClubModalProps> = ({ isOpen, onClose }) => {
             {errors.submarineId && (
               <p className="mt-1 text-red-400 text-sm">{errors.submarineId.message}</p>
             )}
+          </div>
+
+          <div>
+            <label htmlFor="aboutMe" className="block text-white/80 mb-1">About Me (Optional)</label>
+            <Textarea
+              id="aboutMe"
+              {...register('aboutMe')}
+              className="w-full px-4 py-2 bg-navy-light/30 border border-white/20 rounded-lg text-white focus:outline-none focus:border-gold"
+              rows={3}
+            />
+            {/* No error display needed as it's optional */}
           </div>
 
           <button

--- a/src/pages/api/join-club.ts
+++ b/src/pages/api/join-club.ts
@@ -37,8 +37,8 @@ export default async function handler(
       sheetName: SHEET_NAME
     });
 
-    const { name, phone, email } = req.body;
-    console.log('Received form data:', { name, phone, email });
+    const { name, phone, email, aboutMe, submarineId } = req.body;
+    console.log('Received form data:', { name, phone, email, aboutMe, submarineId });
 
     // Validate required fields
     if (!name || !phone || !email) {
@@ -53,14 +53,14 @@ export default async function handler(
     const timestamp = new Date().toISOString();
 
     // Prepare the row data
-    const values = [[timestamp, name, phone, email]];
+    const values = [[timestamp, name, phone, email, submarineId || '', aboutMe || '']]; // Default to empty string if not provided
     console.log('Prepared values for spreadsheet:', values);
 
     try {
       // First, verify we can access the spreadsheet and get sheet info
       const spreadsheet = await sheets.spreadsheets.get({
         spreadsheetId: SPREADSHEET_ID,
-        ranges: [`${SHEET_NAME}!A:D`],
+        ranges: [`${SHEET_NAME}!A:F`], // Adjusted range to include potential new column
         includeGridData: false
       });
       
@@ -75,7 +75,7 @@ export default async function handler(
       // Then append the data
       const response = await sheets.spreadsheets.values.append({
         spreadsheetId: SPREADSHEET_ID,
-        range: `${SHEET_NAME}!A:D`,
+        range: `${SHEET_NAME}!A:F`, // Adjusted range for appending
         valueInputOption: 'USER_ENTERED',
         insertDataOption: 'INSERT_ROWS',
         requestBody: {


### PR DESCRIPTION
This commit introduces an optional 'About Me' textarea to the 'Join Club' modal and updates the backend API to store this information.

Key changes:

- Modified `src/pages/api/join-club.ts`:
    - Accepts new optional fields `aboutMe` and `submarineId` in the request body.
    - Appends these fields to the Google Sheet. The data is now stored in the order: `timestamp, name, phone, email, submarineId, aboutMe`.
    - Updated Google Sheets range to `A:F`.
    - If `aboutMe` or `submarineId` are not provided, they default to an empty string.

- Updated `src/components/modals/JoinClubModal.tsx`:
    - Added a `Textarea` component for the 'About Me (Optional)' field.
    - Registered `aboutMe` with `react-hook-form`.
    - The `FormData` interface within the component was updated to include `aboutMe?: string;`.
    - The `onSubmit` function now includes `aboutMe` (and the existing `submarineId`) in the payload sent to the API.

- Verified that no shared type definitions in `src/types/` required updates for these changes.

The 'Join Club' functionality now allows you to provide additional free-text information about yourselves, and also correctly captures the existing 'Submarine ID' field, storing both in the backend Google Sheet.